### PR TITLE
Allow a Plugin Provided URL

### DIFF
--- a/docs/demo-4.py
+++ b/docs/demo-4.py
@@ -1,0 +1,130 @@
+from wsrepl import Plugin
+import requests
+
+# Set to None if no proxy required
+plugin_proxy = {
+    "http": "http://127.0.0.1:8080",
+    "https": "http://127.0.0.1:8080"
+}
+
+class MultiStepAuthDemo(Plugin):
+    url = None # Required to pass dynamic wss url to MessageHandler.py
+
+    def init(self):
+        # Step one: Get a JWT
+        response = self.send_jwt_request()
+        jwt_token = self.extract_jwt_from_response(response)
+        if jwt_token:
+            # Step 2: Get a access/bearer token
+            response_jwt = self.request_access_token(jwt_token)   
+            access_token = self.extract_access_token_from_response(response_jwt)
+            if access_token:
+                # Step 3: Get the dynamic wss link 
+                wss_start = self.get_wss_endpoint(access_token)
+                self.url = self.extract_url_from_response(wss_start)
+    
+    def send_jwt_request(self):
+        url = "https://example.com/users/auth"
+        headers = {
+            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/112.0",
+            "Accept": "application/json",
+            "Accept-Language": "en-US,en;q=0.5",
+            "Accept-Encoding": "gzip, deflate",
+            "Content-Type": "application/x-www-form-urlencoded",
+            "Origin": "https://example-origin.com",
+            "Referer": "https://example-referer.com/",
+            "Sec-Fetch-Dest": "empty",
+            "Sec-Fetch-Mode": "cors",
+            "Sec-Fetch-Site": "cross-site"
+        }
+
+        data = {
+            "clientId": "your-client-id",
+            "secret": "your-client-secret",
+            "identity": "user-identity",
+            "aud": "public",
+            "isAnonymous": "true",
+            "sid": "session-id",
+            "page": "contactus",
+            "lang": "en_US",
+            "role": "VISITOR"
+        }
+
+        response = requests.post(url, headers=headers, data=data, proxies=plugin_proxy, verify=False)
+        return response
+
+    def extract_jwt_from_response(self, response):
+        try:
+            json_data = response.json()
+            jwt_token = json_data.get("token")
+            return jwt_token
+        except ValueError:
+            return None
+
+    def request_access_token(self, jwt_token):
+        url = "https://example.com/api/token/jwtgrant"
+        headers = {
+            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/112.0",
+            "Accept": "*/*",
+            "Accept-Language": "en-US,en;q=0.5",
+            "Accept-Encoding": "gzip, deflate",
+            "Content-Type": "application/json",
+            "Origin": "https://example-origin.com",
+            "Referer": "https://example-referer.com/",
+            "Sec-Fetch-Dest": "empty",
+            "Sec-Fetch-Mode": "cors",
+            "Sec-Fetch-Site": "cross-site"
+        }
+
+        data = {
+            "assertion": jwt_token,
+            "botInfo": {
+                "chatBot": "example-bot",
+                "botId": "task-bot-id"
+            }
+        }
+
+        response = requests.post(url, headers=headers, json=data, proxies=plugin_proxy, verify=False)
+        return response
+
+    def extract_access_token_from_response(self, response):
+        try:
+            json_data = response.json()
+            access_token = json_data["authorization"]["accessToken"]
+            return access_token
+        except (ValueError, KeyError):
+            return None
+
+    def get_wss_endpoint(self, access_token):
+        url = "https://example.com/api/chat/start"
+        headers = {
+            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/112.0",
+            "Accept": "application/json",
+            "Accept-Language": "en-US,en;q=0.5",
+            "Accept-Encoding": "gzip, deflate",
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {access_token}",
+            "Origin": "https://example-origin.com",
+            "Referer": "https://example-referer.com/",
+            "Sec-Fetch-Dest": "empty",
+            "Sec-Fetch-Mode": "cors",
+            "Sec-Fetch-Site": "cross-site"
+        }
+
+        data = {
+            "botInfo": {
+                "chatBot": "example-bot",
+                "botId": "task-bot-id"
+            }
+        }
+
+        response = requests.post(url, headers=headers, json=data, proxies=plugin_proxy, verify=False)
+        return response
+
+    def extract_url_from_response(self, response):
+        try:
+            json_data = response.json()
+            url = json_data["endpoint"]
+            return url
+        except (ValueError, KeyError):
+            return None

--- a/wsrepl/MessageHandler.py
+++ b/wsrepl/MessageHandler.py
@@ -36,16 +36,15 @@ class MessageHandler:
                  plugin_provided_url: bool | None   = None) -> None:
 
         self.app = app
+        self.plugin = load_plugin(plugin_path)(message_handler=self)
         if(plugin_provided_url):
-            self.plugin = load_plugin(plugin_path)(message_handler=self)
             try:
-                self.url = self.plugin.url
-                print("URL from plugin = " + self.url)
+                url = self.plugin.url
+                print("URL from plugin = " + url)
             except:
                 print("Failed to get URL path from plugin. Exiting...")
                 exit()  
-        else:
-            self.plugin = load_plugin(plugin_path)(message_handler=self)    
+
         self.initial_messages: list[WSMessage] = self._load_initial_messages(initial_msgs_file)
         processed_headers: OrderedDict = self._process_headers(headers, headers_file, user_agent, origin, cookies)
 
@@ -53,7 +52,7 @@ class MessageHandler:
             # Stuff WebsocketConnection needs to call back to us
             async_handler=self,
             # WebSocketApp args
-            url=self.url,
+            url=url,
             header=processed_headers
         )
 
@@ -71,7 +70,6 @@ class MessageHandler:
             'reconnect': reconnect_interval
         }
 
-        print("test")
         self.is_stopped = threading.Event()
 
         # Regular ping thread, conforming to RFC 6455 (ping uses opcode 0x9, pong uses 0xA, data is arbitrary but must be the same)

--- a/wsrepl/app.py
+++ b/wsrepl/app.py
@@ -26,26 +26,27 @@ class WSRepl(App):
                  # URL is the only required argument
                  url: str,
                  # UI settings
-                 small: bool                    = False,
+                 small: bool                        = False,
                  # Websocket settings
-                 user_agent: str | None         = None,
-                 origin: str | None             = None,
-                 cookies: list[str] | None      = None,
-                 headers: list[str] | None      = None,
-                 headers_file: str | None       = None,
-                 ping_interval: int | float     = 24, # 0 -> disable auto ping
-                 hide_ping_pong: bool           = False,
-                 ping_0x1_interval: int | float = 24, # 0 -> disable fake ping
-                 ping_0x1_payload: str | None   = None,
-                 pong_0x1_payload: str | None   = None,
-                 hide_0x1_ping_pong: bool       = False,
-                 reconnect_interval: int        = 0,
-                 proxy: str | None              = None,
-                 verify_tls: bool               = True,
+                 user_agent: str | None             = None,
+                 origin: str | None                 = None,
+                 cookies: list[str] | None          = None,
+                 headers: list[str] | None          = None,
+                 headers_file: str | None           = None,
+                 ping_interval: int | float         = 24, # 0 -> disable auto ping
+                 hide_ping_pong: bool               = False,
+                 ping_0x1_interval: int | float     = 24, # 0 -> disable fake ping
+                 ping_0x1_payload: str | None       = None,
+                 pong_0x1_payload: str | None       = None,
+                 hide_0x1_ping_pong: bool           = False,
+                 reconnect_interval: int            =    0,
+                 proxy: str | None                  = None,
+                 verify_tls: bool                   = True,
                  # Other
-                 initial_msgs_file: str | None  = None,
-                 plugin_path: str | None        = None,
-                 verbosity: int                 = 3) -> None:
+                 initial_msgs_file: str | None      = None,
+                 plugin_path: str | None            = None,
+                 plugin_provided_url: bool | None   = None,
+                 verbosity: int                     = 3) -> None:
         super().__init__()
 
         # Small UI
@@ -62,7 +63,7 @@ class WSRepl(App):
             ping_0x1_interval=ping_0x1_interval, ping_0x1_payload=ping_0x1_payload, pong_0x1_payload=pong_0x1_payload,
             hide_0x1_ping_pong=hide_0x1_ping_pong,
             reconnect_interval=reconnect_interval, proxy=proxy, verify_tls=verify_tls,
-            initial_msgs_file=initial_msgs_file, plugin_path=plugin_path
+            initial_msgs_file=initial_msgs_file, plugin_path=plugin_path, plugin_provided_url=plugin_provided_url
         )
 
         # These are set in compose()

--- a/wsrepl/cli.py
+++ b/wsrepl/cli.py
@@ -4,8 +4,8 @@ from wsrepl import WSRepl
 
 parser = argparse.ArgumentParser(description='Websocket Client')
 # Pass URL either as -u or as a positional argument
-parser.add_argument('-u', '--url',               type=str,                                     help='Websocket URL (e.g. wss://echo.websocket.org)')
-parser.add_argument('url_positional', nargs='?', type=str, help='Websocket URL (e.g. wss://echo.websocket.org)')
+parser.add_argument('-u', '--url',               type=str,                                      help='Websocket URL (e.g. wss://echo.websocket.org)')
+parser.add_argument('url_positional', nargs='?', type=str,                                      help='Websocket URL (e.g. wss://echo.websocket.org)')
 
 # curl compatible args, this is the stuff that Burp uses in a 'Copy as curl command' menu action
 parser.add_argument('-i', '--include',                      action='store_true', default=False, help='No effect, just for curl compatibility')
@@ -15,19 +15,19 @@ parser.add_argument('-X', '--request',            type=str,                     
 parser.add_argument('-H', '--header',                       action='append',                    help='Additional header (e.g. "X-Header: value"), can be used multiple times')
 parser.add_argument('-b', '--cookie',                       action='append',                    help='Cookie header (e.g. "name=value"), can be used multiple times')
 # curl compatible args, used by Chrome's 'Copy as cURL' menu action
-parser.add_argument('--compressed',                       action='store_true', default=False, help='No effect, just for curl compatibility')
+parser.add_argument('--compressed',                         action='store_true', default=False, help='No effect, just for curl compatibility')
 
 parser.add_argument('-S', '--small',                        action='store_true', default=False, help='Smaller UI')
 parser.add_argument('-A', '--user-agent',         type=str,                                     help='User-Agent header')
 parser.add_argument('-O', '--origin',             type=str,                                     help='Origin header')
 parser.add_argument('-F', '--headers-file',       type=str,                                     help='Additional headers file (e.g. "headers.txt")')
-parser.add_argument('--no-native-ping',                     action='store_true', default=False, help='Disable native ping/pong messages')
-parser.add_argument('--ping-interval',            type=int,                      default=24,    help='Ping interval (seconds)')
-parser.add_argument('--hide-ping-pong',                     action='store_true', default=False, help='Hide ping/pong messages')
-parser.add_argument('--ping-0x1-interval',        type=int,                      default=24,    help='Fake ping (0x1 opcode) interval (seconds)')
-parser.add_argument('--ping-0x1-payload',         type=str,                                     help='Fake ping (0x1 opcode) payload')
-parser.add_argument('--pong-0x1-payload',         type=str,                                     help='Fake pong (0x1 opcode) payload')
-parser.add_argument('--hide-0x1-ping-pong',                  action='store_true', default=False, help='Hide fake ping/pong messages')
+parser.add_argument(      '--no-native-ping',               action='store_true', default=False, help='Disable native ping/pong messages')
+parser.add_argument(      '--ping-interval',      type=int,                      default=24,    help='Ping interval (seconds)')
+parser.add_argument(      '--hide-ping-pong',               action='store_true', default=False, help='Hide ping/pong messages')
+parser.add_argument(      '--ping-0x1-interval',  type=int,                      default=24,    help='Fake ping (0x1 opcode) interval (seconds)')
+parser.add_argument(      '--ping-0x1-payload',   type=str,                                     help='Fake ping (0x1 opcode) payload')
+parser.add_argument(      '--pong-0x1-payload',   type=str,                                     help='Fake pong (0x1 opcode) payload')
+parser.add_argument(      '--hide-0x1-ping-pong',           action='store_true', default=False, help='Hide fake ping/pong messages')
 parser.add_argument('-t', '--ttl',                type=int,                                     help='Heartbeet interval (seconds)')
 parser.add_argument('-p', '--http-proxy',         type=str,                                     help='HTTP Proxy Address (e.g. 127.0.0.1:8080)')
 parser.add_argument('-r', '--reconnect-interval', type=int,                      default=2,     help='Reconnect interval (seconds, default: 2)')

--- a/wsrepl/cli.py
+++ b/wsrepl/cli.py
@@ -33,13 +33,13 @@ parser.add_argument('-p', '--http-proxy',         type=str,                     
 parser.add_argument('-r', '--reconnect-interval', type=int,                      default=2,     help='Reconnect interval (seconds, default: 2)')
 parser.add_argument('-I', '--initial-messages',   type=str,                                     help='Send the messages from this file on connect')
 parser.add_argument('-P', '--plugin',             type=str,                                     help='Plugin file to load')
-parser.add_argument(      '--plugin-provided-url',          action='store_true', default=False, help='Plugin file to load')
+parser.add_argument(      '--plugin-provided-url',          action='store_true', default=False, help='Indicates if plugin provided dynamic url for websockets')
 parser.add_argument('-v', '--verbose',            type=int,                      default=3,     help='Verbosity level, 1-4 default: 3 (errors, warnings, info), 4 adds debug')
 
 def cli():
     args = parser.parse_args()
     url = args.url or args.url_positional
-    if url and not args.plugin_provided_url:
+    if url and args.plugin_provided_url is False:
         # Check and modify the URL protocol if necessary
         if url.startswith('http://'):
             return url.replace('http://', 'ws://', 1)
@@ -47,8 +47,10 @@ def cli():
             return url.replace('https://', 'wss://', 1)
         elif not url.startswith(('ws://', 'wss://')):
             parser.error('Invalid protocol. Supported protocols are http://, https://, ws://, and wss://.')
-    elif args.plugin_provided_url and not args.plugin:
-        parser.error('Please provide a WebSocket URL using either -u as a positional argument or use --plugin-provided-url if the WebSocket URL provided in a plugin')
+    elif args.plugin_provided_url is False and args.plugin is not None:
+        parser.error('Please provide a WebSocket URL using -u or use --plugin-provided-url if the WebSocket URL provided in a plugin')
+    else:
+        parser.error('Please provide either a WebSocket URL using -u or use --plugin-provided-url with --plugin if the WebSocket URL provided in a plugin')
 
     app = WSRepl(
         url=url,

--- a/wsrepl/cli.py
+++ b/wsrepl/cli.py
@@ -49,7 +49,7 @@ def cli():
             parser.error('Invalid protocol. Supported protocols are http://, https://, ws://, and wss://.')
     elif args.plugin_provided_url is False and args.plugin is not None:
         parser.error('Please provide a WebSocket URL using -u or use --plugin-provided-url if the WebSocket URL provided in a plugin')
-    else:
+    elif args.plugin_provided_url is False and args.plugin is None:
         parser.error('Please provide either a WebSocket URL using -u or use --plugin-provided-url with --plugin if the WebSocket URL provided in a plugin')
 
     app = WSRepl(


### PR DESCRIPTION
# Enable Dynamic WSS Endpoints via Plugins
I had an issue when using _wsrepl_ with a test. This test required three requests before a WSS link was provided, and the link would have a dynamic variable indicating the session. 

In the original form, I would have to copy over the new WSS every time, and I couldn't write a plugin for Auth since the link is dynamic. However, now a plugin can provide a URL if specified when executing _wsrepl_.

## Changes 
This pull request has the following changes:

- Updated formatting
- The ability to specify if the plugin provided will pass _wsrepl_ an updated URL after _init()_
- An additional demo that includes multi-step auth and provides _MessageHandler.py_ with an updated URL 

## Notes
The extra parameter seems unnecessary when executing the program, perhaps just checking that the _plugin.url_ isn't _None_ would be more simple? Curious to hear your thoughts!