### PR TITLE
Add method for plugin to set HTTP headers

### DIFF
--- a/wsrepl/Plugin.py
+++ b/wsrepl/Plugin.py
@@ -10,11 +10,16 @@ class Plugin:
         self.messages = []
         self.ping_0x1_payload = ""
         self.pong_0x1_payload = ""
+        self.sets_origin = False
         self.init()
 
     def init(self):
         """Called when the plugin is loaded"""
         pass
+
+    def headers_callback(self):
+        """Set headers on connect and reconnect"""
+        return []
 
     async def send(self, message: WSMessage) -> None:
         """Send a message to the server"""


### PR DESCRIPTION
Hi. This MR adds a method for plugins to set HTTP headers on connection.

### Proposed changes

The function `generate_headers` is called every time a new websocket connection is initialized and the headers are added after headers set on the command line. The plugin can keep state and change the headers for every new connection (e.g. set `X-Forwarded-For` to a new value, or update some token), which wasn't possible until now.

### What remains to be done

The diagram in the repository should be updated. It would be great if the source of the diagram was in the repository too with instructions on how to generate it. Could you share the source of the diagram please?

Before writing more docs I would like to hear your thoughts on the change. Thanks for the tool, it's great.